### PR TITLE
Term synching

### DIFF
--- a/Raft.Test/Communication/CandidateNodeRunnerShould.cs
+++ b/Raft.Test/Communication/CandidateNodeRunnerShould.cs
@@ -34,9 +34,9 @@ namespace Raft.Test.Communication
         }
         
         [Test]
-        public void ResetTimer_WhenMessageFromLeaderReceived()
+        public void ResetTimer_WhenMessageFromNewLeaderReceived()
         {
-            _candidate.ReceiveMessage(new NodeMessage(1, "test", MessageType.Info, "someSender", Guid.Empty));
+            _candidate.ReceiveMessage(new NodeMessage(2, "test", MessageType.Info, "someSender", Guid.Empty));
             
             _timer.Received(1).Reset();
         }

--- a/Raft.Test/Communication/LeaderNodeRunnerShould.cs
+++ b/Raft.Test/Communication/LeaderNodeRunnerShould.cs
@@ -49,25 +49,6 @@ namespace Raft.Test.Communication
         }
 
         [Test]
-        public void CommitUpdate_WhenMajorityConfirmsLogUpdate()
-        {
-            var updateId = Guid.NewGuid();
-            _node.Log.Add(new LogEntry(OperationType.Update, TestValue, updateId));
-            
-            var messageA = new NodeMessage(0, TestValue, MessageType.LogUpdateConfirmation, "A", updateId);
-            var messageB = new NodeMessage(0, TestValue, MessageType.LogUpdateConfirmation, "B", updateId);
-            
-            _leaderNodeRunner.ReceiveMessage(messageA);
-            _node.Log.Last().Type.ShouldBe(OperationType.Update);
-            _messageBroker.DidNotReceiveWithAnyArgs().Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.LogCommit));
-            
-            _leaderNodeRunner.ReceiveMessage(messageB);
-            _node.Log.Last().Type.ShouldBe(OperationType.Commit);
-            _node.Value.ShouldBe(TestValue);
-            _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.LogCommit));
-        }
-        
-        [Test]
         public void DisplayStatus()
         {
             _leaderNodeRunner.ToString().ShouldBe($"{NodeName} (0) L - {_node.Value}");

--- a/Raft.Test/Entities/NodeShould.cs
+++ b/Raft.Test/Entities/NodeShould.cs
@@ -43,5 +43,13 @@ namespace Raft.Test.Entities
             
             _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.VoteRequest));
         }
+
+        [Test]
+        public void VoteForItself_WhenBecomingCandidate()
+        {
+            _node.BecomeCandidate();
+            
+            ((CandidateStatus) _node.Status).ConfirmedNodes.ShouldContain(_node.Name);
+        }
     }
 }

--- a/Raft.Test/Strategy/FollowerStrategyShould.cs
+++ b/Raft.Test/Strategy/FollowerStrategyShould.cs
@@ -53,6 +53,18 @@ namespace Raft.Test.Strategy
             _node.LastLogEntry().Value.ShouldBe("test");
             _node.LastLogEntry().Type.ShouldBe(OperationType.Commit);
         }
+                
+        [TestCase(MessageType.LogUpdate)]
+        [TestCase(MessageType.LogCommit)]
+        public void RejectLogReplicationMessagesFromOlderTerms(MessageType messageType)
+        {
+            _node.Status = new FollowerStatus(2);
+            var logUpdate = new NodeMessage(1, "test", messageType, "L", Guid.Empty);
+            _followerStrategy.RespondToMessage(logUpdate);
+
+            _node.Log.ShouldBeEmpty();
+            _messageBroker.Received(0).Broadcast(Arg.Any<NodeMessage>());
+        }
 
         [Test]
         public void IgnoreLogCommits_ForIrrelevantEntries()
@@ -85,6 +97,8 @@ namespace Raft.Test.Strategy
             
             _messageBroker.Received(0).Broadcast(Arg.Any<NodeMessage>());
         }
+
+        
         
     }
 }

--- a/Raft.Test/Strategy/Timer/CandidateTimerStrategyShould.cs
+++ b/Raft.Test/Strategy/Timer/CandidateTimerStrategyShould.cs
@@ -26,21 +26,31 @@ namespace Raft.Test.Strategy.Timer
         }
         
         [Test]
-        public void ResetTimer_WhenMessageFromLeaderReceived()
+        public void ResetTimer_WhenMessageFromNewLeaderReceived()
         {
-            var nodeMessage = new NodeMessage(0, "ping", MessageType.Info, "Leader", Guid.Empty);
+            var nodeMessage = new NodeMessage(2, "ping", MessageType.Info, "Leader", Guid.Empty);
             var shouldReset = _candidateTimerStrategy.ShouldReset(nodeMessage);
             
             shouldReset.ShouldBeTrue();
         }
         
         [Test]
-        public void ResetTimer_WhenMessageFromAnotherCandidateReceived()
+        public void NotResetTimer_WhenMessageFromOldLeaderReceived()
         {
-            var nodeMessage = new NodeMessage(2, "new candidate", MessageType.VoteRequest, "anotherCandidate", Guid.Empty);
+            var nodeMessage = new NodeMessage(0, "ping", MessageType.Info, "Leader", Guid.Empty);
             var shouldReset = _candidateTimerStrategy.ShouldReset(nodeMessage);
             
-            shouldReset.ShouldBeTrue();
+            shouldReset.ShouldBeFalse();
+        }
+        
+        [TestCase(1)]
+        [TestCase(2)]
+        public void NotResetTimer_WhenMessageFromCandidateReceived(int term)
+        {
+            var nodeMessage = new NodeMessage(term, "new candidate", MessageType.VoteRequest, "anotherCandidate", Guid.Empty);
+            var shouldReset = _candidateTimerStrategy.ShouldReset(nodeMessage);
+            
+            shouldReset.ShouldBeFalse();
         }
         
         [Test]

--- a/Raft.Test/Strategy/Timer/FollowerTimerStrategyShould.cs
+++ b/Raft.Test/Strategy/Timer/FollowerTimerStrategyShould.cs
@@ -34,12 +34,12 @@ namespace Raft.Test.Strategy.Timer
         }
         
         [Test]
-        public void ResetTimer_WhenMessageFromCandidateReceived()
+        public void NotResetTimer_WhenMessageFromCandidateReceived()
         {
             var nodeMessage = new NodeMessage(1, "from candidate", MessageType.VoteRequest, "candidate", Guid.Empty);
             var shouldReset = _followerTimerStrategy.ShouldReset(nodeMessage);
             
-            shouldReset.ShouldBeTrue();
+            shouldReset.ShouldBeFalse();
         }
         
         [Test]

--- a/Raft/Communication/ITimer.cs
+++ b/Raft/Communication/ITimer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Timers;
 
 namespace Raft.Communication
@@ -6,7 +5,6 @@ namespace Raft.Communication
     public interface ITimer
     {
         void Start();
-        void Stop();
         void Reset();
 
         event ElapsedEventHandler Elapsed;

--- a/Raft/Communication/NodeRunner.cs
+++ b/Raft/Communication/NodeRunner.cs
@@ -1,4 +1,3 @@
-using System;
 using NLog;
 using Raft.Entities;
 using Raft.NodeStrategy;

--- a/Raft/Entities/LogEntry.cs
+++ b/Raft/Entities/LogEntry.cs
@@ -20,9 +20,7 @@ namespace Raft.Entities
 
     public enum OperationType
     {
-        Add,
         Update,
-        Remove,
         Commit
     }
 }

--- a/Raft/Entities/Node.cs
+++ b/Raft/Entities/Node.cs
@@ -105,7 +105,10 @@ namespace Raft.Entities
 
             Logger.Debug($"{Name} becomes candidate, term: {newTerm}");
 
-            Status = new CandidateStatus(newTerm);
+            Status = new CandidateStatus(newTerm)
+            {
+                ConfirmedNodes = { Name }
+            };
             SendVoteRequest(newTerm);
         }
     }

--- a/Raft/Entities/Node.cs
+++ b/Raft/Entities/Node.cs
@@ -66,7 +66,7 @@ namespace Raft.Entities
             Broker.Broadcast(logUpdate);
         }
 
-        public void SendVoteRequest(int term)
+        private void SendVoteRequest(int term)
         {
             var message = new NodeMessage(term, Name, MessageType.VoteRequest, Name, Guid.NewGuid());
             Broker.Broadcast(message);

--- a/Raft/Entities/Node.cs
+++ b/Raft/Entities/Node.cs
@@ -72,11 +72,11 @@ namespace Raft.Entities
             Broker.Broadcast(message);
         }
 
-        public void Vote(int term, string leader, Guid electionId)
+        public void Vote(int term, string candidate, Guid electionId)
         {
-            Logger.Debug($"{Name} votes for {leader}");
+            Logger.Debug($"{Name} votes for {candidate}");
             
-            var voteMessage = new NodeMessage(term, leader, MessageType.LeaderVote, Name, electionId);
+            var voteMessage = new NodeMessage(term, candidate, MessageType.LeaderVote, Name, electionId);
             Broker.Broadcast(voteMessage);
         }
 
@@ -87,8 +87,6 @@ namespace Raft.Entities
 
         public void SendPing()
         {
-            Logger.Debug($"{Name} sends ping");
-            
             var voteMessage = new NodeMessage(Status.Term, Name, MessageType.Info, Name, Guid.Empty);
                         Broker.Broadcast(voteMessage);
         }
@@ -96,9 +94,9 @@ namespace Raft.Entities
         public void ResendVoteRequest()
         {
             var newTerm = Status.Term + 1;
+            Logger.Debug($"{Name} resends vote request, term: {newTerm}");
             Status.Term = newTerm;
-            var message = new NodeMessage(newTerm, Name, MessageType.VoteRequest, Name, Guid.NewGuid());
-            Broker.Broadcast(message);
+            SendVoteRequest(newTerm);
         }
 
         public void BecomeCandidate()

--- a/Raft/Entities/NodeMessage.cs
+++ b/Raft/Entities/NodeMessage.cs
@@ -4,14 +4,14 @@ namespace Raft.Entities
 {
     public class NodeMessage
     {
-        public string Value { get; private set; }
-        public MessageType Type { get; private set; }
+        public string Value { get; }
+        public MessageType Type { get; }
 
-        public string SenderName { get; private set; }
+        public string SenderName { get; }
 
-        public int Term { get; set; }
+        public int Term { get; }
 
-        public Guid Id { get; private set; }
+        public Guid Id { get; }
         
         public NodeMessage(int term, string value, MessageType type, string senderName, Guid id)
         {

--- a/Raft/NodeStrategy/BaseStrategy.cs
+++ b/Raft/NodeStrategy/BaseStrategy.cs
@@ -14,6 +14,7 @@ namespace Raft.NodeStrategy
             Logger.Debug($"{Node.Name} becomes leader, term: {Node.Status.Term}");
             
             Node.Status = new LeaderStatus(Node.Status.Term);
+            Node.SendPing();
         }
 
         protected void BecomeFollower(NodeMessage message)
@@ -25,8 +26,15 @@ namespace Raft.NodeStrategy
 
         protected void ConfirmLogUpdate(NodeMessage message)
         {
-            Node.UpdateLog(message, message.Id);
-            Node.ConfirmLogUpdate(message.Id);
+            
+                Node.UpdateLog(message, message.Id);
+                Node.ConfirmLogUpdate(message.Id);
+
+        }
+
+        protected void CommitLog(NodeMessage message)
+        {
+            Node.CommitLog(message);
         }
     }
 }

--- a/Raft/NodeStrategy/BaseStrategy.cs
+++ b/Raft/NodeStrategy/BaseStrategy.cs
@@ -18,7 +18,7 @@ namespace Raft.NodeStrategy
 
         protected void BecomeFollower(NodeMessage message)
         {
-            Logger.Debug($"{Node.Name} becomes follower of {message.SenderName}, term: {Node.Status.Term}");
+            Logger.Debug($"{Node.Name} becomes follower of {message.SenderName}, term: {message.Term}");
             
             Node.Status = new FollowerStatus(message.Term);
         }

--- a/Raft/NodeStrategy/BaseStrategy.cs
+++ b/Raft/NodeStrategy/BaseStrategy.cs
@@ -6,13 +6,13 @@ namespace Raft.NodeStrategy
     public abstract class BaseStrategy
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-        
+
         protected Node Node;
 
         protected void BecomeLeader()
         {
             Logger.Debug($"{Node.Name} becomes leader, term: {Node.Status.Term}");
-            
+
             Node.Status = new LeaderStatus(Node.Status.Term);
             Node.SendPing();
         }
@@ -20,16 +20,14 @@ namespace Raft.NodeStrategy
         protected void BecomeFollower(NodeMessage message)
         {
             Logger.Debug($"{Node.Name} becomes follower of {message.SenderName}, term: {message.Term}");
-            
+
             Node.Status = new FollowerStatus(message.Term);
         }
 
         protected void ConfirmLogUpdate(NodeMessage message)
         {
-            
-                Node.UpdateLog(message, message.Id);
-                Node.ConfirmLogUpdate(message.Id);
-
+            Node.UpdateLog(message, message.Id);
+            Node.ConfirmLogUpdate(message.Id);
         }
 
         protected void CommitLog(NodeMessage message)

--- a/Raft/NodeStrategy/CandidateStrategy.cs
+++ b/Raft/NodeStrategy/CandidateStrategy.cs
@@ -29,22 +29,35 @@ namespace Raft.NodeStrategy
             switch (message.Type)
             {
                 case MessageType.LogUpdate:
-                    BecomeFollower(message);
-                    ConfirmLogUpdate(message);
+                    if (message.Term > Node.Status.Term)
+                    {
+                        BecomeFollower(message);
+                        ConfirmLogUpdate(message);
+                    }
+                    
                     break;
 
                 case MessageType.LogUpdateConfirmation:
                     break;
 
                 case MessageType.LogCommit:
-                    BecomeFollower(message);
+                    if (message.Term > Node.Status.Term)
+                    {
+                        BecomeFollower(message);
+                        CommitLog(message);
+                    }
+
                     break;
 
                 case MessageType.ValueUpdate:
                     break;
                 
                 case MessageType.Info:
-                    BecomeFollower(message);
+                    if (message.Term > Node.Status.Term)
+                    {
+                        BecomeFollower(message);
+                    }
+
                     break;
                 
                 case MessageType.VoteRequest:
@@ -56,9 +69,8 @@ namespace Raft.NodeStrategy
                     break;
                 
                 case MessageType.LeaderVote:
-                    if (message.Term > Node.Status.Term)
+                    if (message.Value != Node.Name)
                     {
-                        BecomeFollower(message);
                         break;
                     }
                     
@@ -67,6 +79,7 @@ namespace Raft.NodeStrategy
                     {
                         Logger.Debug($"{Node.Name} has majority {_votes.Count} / {_nodesCount}");
                         BecomeLeader();
+                        
                     }
                     break;
                 

--- a/Raft/NodeStrategy/CandidateStrategy.cs
+++ b/Raft/NodeStrategy/CandidateStrategy.cs
@@ -12,7 +12,7 @@ namespace Raft.NodeStrategy
     public class CandidateStrategy : BaseStrategy, IMessageResponseStrategy
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-        
+
         private readonly int _nodesCount;
         private readonly HashSet<string> _votes;
 
@@ -34,7 +34,7 @@ namespace Raft.NodeStrategy
                         BecomeFollower(message);
                         ConfirmLogUpdate(message);
                     }
-                    
+
                     break;
 
                 case MessageType.LogUpdateConfirmation:
@@ -51,7 +51,7 @@ namespace Raft.NodeStrategy
 
                 case MessageType.ValueUpdate:
                     break;
-                
+
                 case MessageType.Info:
                     if (message.Term > Node.Status.Term)
                     {
@@ -59,36 +59,36 @@ namespace Raft.NodeStrategy
                     }
 
                     break;
-                
+
                 case MessageType.VoteRequest:
                     if (message.Term > Node.Status.Term)
                     {
                         BecomeFollower(message);
                         Node.Vote(message.Term, message.SenderName, message.Id);
                     }
+
                     break;
-                
+
                 case MessageType.LeaderVote:
                     if (message.Value != Node.Name)
                     {
                         break;
                     }
-                    
+
                     AddVote(message);
                     if (HasMajority())
                     {
                         Logger.Debug($"{Node.Name} has majority {_votes.Count} / {_nodesCount}");
                         BecomeLeader();
-                        
                     }
+
                     break;
-                
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
         }
 
-        
 
         private void AddVote(NodeMessage message)
         {

--- a/Raft/NodeStrategy/FollowerStrategy.cs
+++ b/Raft/NodeStrategy/FollowerStrategy.cs
@@ -7,14 +7,13 @@ namespace Raft.NodeStrategy
     /// <summary>
     /// Follower node strategy for responding to Raft messages
     /// </summary>
-    public class FollowerStrategy: BaseStrategy, IMessageResponseStrategy
+    public class FollowerStrategy : BaseStrategy, IMessageResponseStrategy
     {
-
         public FollowerStrategy(Node node)
         {
             Node = node;
         }
-        
+
         public void RespondToMessage(NodeMessage message)
         {
             switch (message.Type)
@@ -40,16 +39,17 @@ namespace Raft.NodeStrategy
 
                 case MessageType.ValueUpdate:
                     break;
-                
+
                 case MessageType.Info:
                     break;
-                
+
                 case MessageType.VoteRequest:
                     if (!Node.HasVotedInTerm(message.Term))
                     {
                         Node.Status.Term = message.Term;
                         Vote(message);
                     }
+
                     break;
                 case MessageType.LeaderVote:
                     break;

--- a/Raft/NodeStrategy/FollowerStrategy.cs
+++ b/Raft/NodeStrategy/FollowerStrategy.cs
@@ -20,14 +20,22 @@ namespace Raft.NodeStrategy
             switch (message.Type)
             {
                 case MessageType.LogUpdate:
-                    ConfirmLogUpdate(message);
+                    if (message.Term == Node.Status.Term)
+                    {
+                        ConfirmLogUpdate(message);
+                    }
+
                     break;
 
                 case MessageType.LogUpdateConfirmation:
                     break;
 
                 case MessageType.LogCommit:
-                    CommitLog(message);
+                    if (message.Term == Node.Status.Term)
+                    {
+                        CommitLog(message);
+                    }
+
                     break;
 
                 case MessageType.ValueUpdate:
@@ -53,11 +61,6 @@ namespace Raft.NodeStrategy
         private void Vote(NodeMessage message)
         {
             Node.Vote(message.Term, message.SenderName, message.Id);
-        }
-
-        private void CommitLog(NodeMessage message)
-        {
-            Node.CommitLog(message);
         }
     }
 }

--- a/Raft/NodeStrategy/LeaderStrategy.cs
+++ b/Raft/NodeStrategy/LeaderStrategy.cs
@@ -42,15 +42,21 @@ namespace Raft.NodeStrategy
                     break;
 
                 case MessageType.LogUpdate:
-                    BecomeFollowerIfSentFromNewerLeader(message);
+                    BecomeFollowerIfSentFromNewerTerm(message);
                     break;
                 case MessageType.LogCommit:
-                    BecomeFollowerIfSentFromNewerLeader(message);
+                    BecomeFollowerIfSentFromNewerTerm(message);
                     break;
                 case MessageType.Info:
-                    BecomeFollowerIfSentFromNewerLeader(message);
+                    BecomeFollowerIfSentFromNewerTerm(message);
                     break;
                 case MessageType.VoteRequest:
+                    if (FromHigherTerm(message))
+                    {
+                        BecomeFollower(message);
+                        Node.Vote(message.Term, message.SenderName, message.Id);
+                    }
+
                     break;
                 case MessageType.LeaderVote:
                     break;
@@ -59,15 +65,15 @@ namespace Raft.NodeStrategy
             }
         }
 
-        private void BecomeFollowerIfSentFromNewerLeader(NodeMessage message)
+        private void BecomeFollowerIfSentFromNewerTerm(NodeMessage message)
         {
-            if (FromLeaderWithHigherTerm(message))
+            if (FromHigherTerm(message))
             {
                 BecomeFollower(message);
             }
         }
 
-        private bool FromLeaderWithHigherTerm(NodeMessage message)
+        private bool FromHigherTerm(NodeMessage message)
         {
             return message.Term >= Node.Status.Term;
         }

--- a/Raft/NodeStrategy/LeaderStrategy.cs
+++ b/Raft/NodeStrategy/LeaderStrategy.cs
@@ -81,6 +81,7 @@ namespace Raft.NodeStrategy
         private void ResetUpdateConfirmations()
         {
             _status.ConfirmedNodes.Clear();
+            _status.ConfirmedNodes.Add(Node.Name);
         }
 
         private void RequestLogUpdate(NodeMessage message)

--- a/Raft/NodeStrategy/LeaderStrategy.cs
+++ b/Raft/NodeStrategy/LeaderStrategy.cs
@@ -7,7 +7,7 @@ namespace Raft.NodeStrategy
     /// <summary>
     /// Leader node strategy for responding to Raft messages
     /// </summary>
-    public class LeaderStrategy: BaseStrategy, IMessageResponseStrategy
+    public class LeaderStrategy : BaseStrategy, IMessageResponseStrategy
     {
         private readonly LeaderStatus _status;
 
@@ -19,7 +19,7 @@ namespace Raft.NodeStrategy
             Node = node;
             _status = node.Status as LeaderStatus;
         }
-        
+
         public void RespondToMessage(NodeMessage message)
         {
             switch (message.Type)

--- a/Raft/NodeStrategy/StrategySelector.cs
+++ b/Raft/NodeStrategy/StrategySelector.cs
@@ -11,7 +11,7 @@ namespace Raft.NodeStrategy
     public class StrategySelector
     {
         private readonly int _count;
-        
+
         public StrategySelector(int count)
         {
             _count = count;
@@ -21,13 +21,13 @@ namespace Raft.NodeStrategy
         {
             switch (node.Status.Name)
             {
-                    case NodeStatus.Follower:
-                        return new FollowerStrategy(node);
-                    case NodeStatus.Leader:
-                        return new LeaderStrategy(node, _count);
-                    case NodeStatus.Candidate:
-                        return new CandidateStrategy(node, _count);
-                    default: throw new ArgumentException("Unknown status");
+                case NodeStatus.Follower:
+                    return new FollowerStrategy(node);
+                case NodeStatus.Leader:
+                    return new LeaderStrategy(node, _count);
+                case NodeStatus.Candidate:
+                    return new CandidateStrategy(node, _count);
+                default: throw new ArgumentException("Unknown status");
             }
         }
 

--- a/Raft/NodeStrategy/Timer/CandidateTimerStrategy.cs
+++ b/Raft/NodeStrategy/Timer/CandidateTimerStrategy.cs
@@ -19,7 +19,7 @@ namespace Raft.NodeStrategy.Timer
 
         public bool ShouldReset(NodeMessage message)
         {
-            return FromLeader(message) || FromCandidate(message);
+            return FromLeader(message) && message.Term > _node.Status.Term;// || FromCandidate(message) && message.Term > _node.Status.Term;
         }
     }
 }

--- a/Raft/NodeStrategy/Timer/CandidateTimerStrategy.cs
+++ b/Raft/NodeStrategy/Timer/CandidateTimerStrategy.cs
@@ -3,7 +3,7 @@ using Raft.Entities;
 
 namespace Raft.NodeStrategy.Timer
 {
-    public class CandidateTimerStrategy : BaseTimerStrategy, ITimerStrategy 
+    public class CandidateTimerStrategy : BaseTimerStrategy, ITimerStrategy
     {
         private readonly Node _node;
 
@@ -19,7 +19,7 @@ namespace Raft.NodeStrategy.Timer
 
         public bool ShouldReset(NodeMessage message)
         {
-            return FromLeader(message) && message.Term > _node.Status.Term;// || FromCandidate(message) && message.Term > _node.Status.Term;
+            return FromLeader(message) && message.Term > _node.Status.Term;
         }
     }
 }

--- a/Raft/NodeStrategy/Timer/FollowerTimerStrategy.cs
+++ b/Raft/NodeStrategy/Timer/FollowerTimerStrategy.cs
@@ -19,7 +19,7 @@ namespace Raft.NodeStrategy.Timer
 
         public bool ShouldReset(NodeMessage message)
         {
-            return FromLeader(message);
+            return FromLeader(message) && message.Term >= _node.Status.Term;
         }
     }
 }

--- a/Raft/NodeStrategy/Timer/FollowerTimerStrategy.cs
+++ b/Raft/NodeStrategy/Timer/FollowerTimerStrategy.cs
@@ -19,7 +19,7 @@ namespace Raft.NodeStrategy.Timer
 
         public bool ShouldReset(NodeMessage message)
         {
-            return FromLeader(message) || FromCandidate(message);
+            return FromLeader(message);// || FromCandidate(message);
         }
     }
 }

--- a/Raft/NodeStrategy/Timer/FollowerTimerStrategy.cs
+++ b/Raft/NodeStrategy/Timer/FollowerTimerStrategy.cs
@@ -19,7 +19,7 @@ namespace Raft.NodeStrategy.Timer
 
         public bool ShouldReset(NodeMessage message)
         {
-            return FromLeader(message);// || FromCandidate(message);
+            return FromLeader(message);
         }
     }
 }

--- a/Raft/Runner/RaftRunner.cs
+++ b/Raft/Runner/RaftRunner.cs
@@ -13,7 +13,7 @@ namespace Raft.Runner
 {
     public class RaftRunner
     {
-        private static readonly string[] Nodes = new[] {"L", "A", "B", "C", "D"};
+        private static readonly string[] Nodes = {"L", "A", "B", "C", "D"};
         
         private static readonly TimeoutGenerator TimeoutGenerator = new TimeoutGenerator();
         private readonly Collection<IMessageBrokerListener> _nodeRunners = new Collection<IMessageBrokerListener>();


### PR DESCRIPTION
Make nodes take term of message into account when responding. 

Followers 
- ignore old term messages.
- do not reset timeout on candidate message.

Leaders
- send ping immediately after elected
- vote for newer candidates and become followers
- become followers of newer leaders
- confirm log updates they initiate

Candidates
- vote for themselves
- abandon election if they find a newer leader
