### PR TITLE
Leader election safety

### DIFF
--- a/Raft.Test/Communication/FollowerNodeRunnerShould.cs
+++ b/Raft.Test/Communication/FollowerNodeRunnerShould.cs
@@ -44,7 +44,7 @@ namespace Raft.Test.Communication
         public void Commit_OnLogCommit()
         {
             var updateId = Guid.NewGuid();
-            _node.Log.Add(new LogEntry(OperationType.Update, TestValue, updateId));
+            _node.Log.Add(new LogEntry(OperationType.Update, TestValue, updateId, 0));
             
             var message = new NodeMessage(0, TestValue, MessageType.LogCommit, null, updateId);
             _nodeRunner.ReceiveMessage(message);

--- a/Raft.Test/Entities/NodeShould.cs
+++ b/Raft.Test/Entities/NodeShould.cs
@@ -1,3 +1,4 @@
+using System;
 using NSubstitute;
 using NUnit.Framework;
 using Raft.Entities;
@@ -42,6 +43,15 @@ namespace Raft.Test.Entities
             _node.BecomeCandidate();
             
             _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.VoteRequest));
+        }
+
+        [Test]
+        public void SendLastLogEntryTermAndIndexWithVoteRequest()
+        {
+            _node.Log.Add(new LogEntry(OperationType.Update, "value", Guid.NewGuid(), 1));
+            _node.BecomeCandidate();
+            
+            _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.VoteRequest && m.Value.Equals("1,0")));
         }
 
         [Test]

--- a/Raft.Test/Strategy/CandidateStrategyShould.cs
+++ b/Raft.Test/Strategy/CandidateStrategyShould.cs
@@ -96,7 +96,7 @@ namespace Raft.Test.Strategy
         public void BecomeFollowerAndCommitLog_OnLogCommitFromNewLeader()
         {
             var entryId = Guid.Empty;
-            _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId));
+            _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId, 2));
             var fromLeader = new NodeMessage(2, "new value", MessageType.LogCommit, "L", entryId);
             _candidateStrategy.RespondToMessage(fromLeader);
             

--- a/Raft.Test/Strategy/CandidateStrategyShould.cs
+++ b/Raft.Test/Strategy/CandidateStrategyShould.cs
@@ -117,7 +117,7 @@ namespace Raft.Test.Strategy
         }
 
         [Test]
-        public void BecomeFollower_OnNewerTermStarted()
+        public void BecomeFollowerAndVot_OnNewerTermStarted()
         {
             var voteRequest = new NodeMessage(CandidateTerm + 1, CandidateName, MessageType.VoteRequest, "C", Guid.Empty);
             _candidateStrategy.RespondToMessage(voteRequest);
@@ -126,6 +126,18 @@ namespace Raft.Test.Strategy
             
             _messageBroker.Received(1)
                 .Broadcast(message: Arg.Is<NodeMessage>(m => m.Type == MessageType.LeaderVote && m.SenderName == CandidateName));
+        }
+
+        [Test]
+        public void IgnoreStaleMessages()
+        {
+            var voteRequest = new NodeMessage(CandidateTerm - 1, CandidateName, MessageType.VoteRequest, "C", Guid.Empty);
+            _candidateStrategy.RespondToMessage(voteRequest);
+            
+            _node.Status.Name.ShouldBe(NodeStatus.Candidate);
+            
+            _messageBroker.DidNotReceiveWithAnyArgs()
+                .Broadcast(message: Arg.Any<NodeMessage>());
         }
 
     }

--- a/Raft.Test/Strategy/FollowerStrategyShould.cs
+++ b/Raft.Test/Strategy/FollowerStrategyShould.cs
@@ -11,6 +11,7 @@ namespace Raft.Test.Strategy
     public class FollowerStrategyShould
     {
         private const string FollowerName = "F";
+        private const int FollowerTerm = 0;
         
         private Node _node;
         private FollowerStrategy _followerStrategy;
@@ -22,7 +23,7 @@ namespace Raft.Test.Strategy
             _messageBroker = Substitute.For<IMessageBroker>();
             _node = new Node(FollowerName, _messageBroker)
             {
-                Status = new FollowerStatus(0)
+                Status = new FollowerStatus(FollowerTerm)
             };
             _followerStrategy = new FollowerStrategy(_node);
         }
@@ -30,7 +31,7 @@ namespace Raft.Test.Strategy
         [Test]
         public void UpdateLogAndConfirm_OnLogUpdate()
         {
-            var logUpdate = new NodeMessage(0, "test", MessageType.LogUpdate, "L", Guid.Empty);
+            var logUpdate = new NodeMessage(FollowerTerm, "test", MessageType.LogUpdate, "L", Guid.Empty);
             _followerStrategy.RespondToMessage(logUpdate);
 
             _node.LastLogEntry().Value.ShouldBe("test");
@@ -45,9 +46,9 @@ namespace Raft.Test.Strategy
         public void CommitLogAndUpdateValue_OnLogCommit()
         {
             var entryId = Guid.NewGuid();
-            _node.Log.Add(new LogEntry(OperationType.Update, "test", entryId));
+            _node.Log.Add(new LogEntry(OperationType.Update, "test", entryId, FollowerTerm));
             
-            var logUpdate = new NodeMessage(0, "test", MessageType.LogCommit, "L", entryId);
+            var logUpdate = new NodeMessage(FollowerTerm, "test", MessageType.LogCommit, "L", entryId);
             _followerStrategy.RespondToMessage(logUpdate);
             
             _node.LastLogEntry().Value.ShouldBe("test");
@@ -63,16 +64,16 @@ namespace Raft.Test.Strategy
             _followerStrategy.RespondToMessage(logUpdate);
 
             _node.Log.ShouldBeEmpty();
-            _messageBroker.Received(0).Broadcast(Arg.Any<NodeMessage>());
+            _messageBroker.DidNotReceiveWithAnyArgs().Broadcast(Arg.Any<NodeMessage>());
         }
 
         [Test]
         public void IgnoreLogCommits_ForIrrelevantEntries()
         {
             var entryId = Guid.NewGuid();
-            _node.Log.Add(new LogEntry(OperationType.Update, "current entry", entryId));
+            _node.Log.Add(new LogEntry(OperationType.Update, "current entry", entryId, FollowerTerm));
             
-            var logUpdate = new NodeMessage(0, "irrelevant entry", MessageType.LogCommit, "L", Guid.NewGuid());
+            var logUpdate = new NodeMessage(FollowerTerm, "irrelevant entry", MessageType.LogCommit, "L", Guid.NewGuid());
             _followerStrategy.RespondToMessage(logUpdate);
             
             _node.LastLogEntry().Value.ShouldBe("current entry");
@@ -82,7 +83,7 @@ namespace Raft.Test.Strategy
         [Test]
         public void VoteForLeader_WhenNotVotedInTerm()
         {
-            var voteRequest = new NodeMessage(1, "new candidate", MessageType.VoteRequest, "C", Guid.NewGuid());
+            var voteRequest = new NodeMessage(1, "0,-1", MessageType.VoteRequest, "C", Guid.NewGuid());
             _followerStrategy.RespondToMessage(voteRequest);
             
             _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(
@@ -92,13 +93,25 @@ namespace Raft.Test.Strategy
         [Test]
         public void NotVoteForLeader_WhenAlreadyVotedInTerm()
         {
-            var voteRequest = new NodeMessage(0, "new candidate", MessageType.VoteRequest, "C", Guid.NewGuid());
+            var voteRequest = new NodeMessage(FollowerTerm, "new candidate", MessageType.VoteRequest, "C", Guid.NewGuid());
             _followerStrategy.RespondToMessage(voteRequest);
             
-            _messageBroker.Received(0).Broadcast(Arg.Any<NodeMessage>());
+            _messageBroker.DidNotReceiveWithAnyArgs().Broadcast(Arg.Any<NodeMessage>());
         }
 
-        
+        [TestCase(0, 2, false)]
+        [TestCase(2, -1, false)]
+        [TestCase(2, 1, true)]
+        public void DenyVote_WhenCandidateLogNotUpToDate(int term, int lastLogIndex, bool expectation)
+        {
+            _node.Status = new FollowerStatus(1);
+            _node.Log.Add(new LogEntry(OperationType.Update, "value", Guid.NewGuid(), 2));
+            
+            var voteRequest = new NodeMessage(FollowerTerm + 1, $"{term},{lastLogIndex}", MessageType.VoteRequest, "C", Guid.NewGuid());
+            _followerStrategy.RespondToMessage(voteRequest);
+            
+            _messageBroker.Received(expectation ? 1 : 0).Broadcast(Arg.Any<NodeMessage>());
+        }
         
     }
 }

--- a/Raft.Test/Strategy/LeaderStrategyShould.cs
+++ b/Raft.Test/Strategy/LeaderStrategyShould.cs
@@ -38,7 +38,7 @@ namespace Raft.Test.Strategy
         public void AddConfirmations_OnLogUpdateConfirmationReceived()
         {
             var entryId = Guid.NewGuid();
-            _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId));
+            _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId, 1));
             var updateConfirmation = new NodeMessage(1, "new value", MessageType.LogUpdateConfirmation, "A", entryId);
             
             _leaderStrategy.RespondToMessage(updateConfirmation);
@@ -51,7 +51,7 @@ namespace Raft.Test.Strategy
         public void NotCommitLogOrUpdateValue_BeforeMajorityConfirmed()
         {
             var entryId = Guid.NewGuid();
-            _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId));
+            _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId, 1));
             
             var confirmationA = new NodeMessage(1, "new value", MessageType.LogUpdateConfirmation, "A", entryId);
             _leaderStrategy.RespondToMessage(confirmationA);
@@ -66,7 +66,7 @@ namespace Raft.Test.Strategy
         public void CommitLogAndUpdateValue_OnMajorityConfirmed()
         {
             var entryId = Guid.NewGuid();
-            _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId));
+            _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId, 1));
             
             var confirmationA = new NodeMessage(1, "new value", MessageType.LogUpdateConfirmation, "A", entryId);
             _leaderStrategy.RespondToMessage(confirmationA);

--- a/Raft/Entities/INodeStatus.cs
+++ b/Raft/Entities/INodeStatus.cs
@@ -5,5 +5,7 @@ namespace Raft.Entities
         string Name { get; }
 
         int Term { get; set; }
+        
+        int LastVote { get; set; }
     }
 }

--- a/Raft/Entities/LogEntry.cs
+++ b/Raft/Entities/LogEntry.cs
@@ -9,11 +9,14 @@ namespace Raft.Entities
         public string Value { get; }
         public Guid Id { get; }
 
-        public LogEntry(OperationType type, string value, Guid id)
+        public int Term { get; }
+
+        public LogEntry(OperationType type, string value, Guid id, int term)
         {
             Type = type;
             Value = value;
             Id = id;
+            Term = term;
         }
 
     }

--- a/Raft/Entities/Node.cs
+++ b/Raft/Entities/Node.cs
@@ -28,7 +28,7 @@ namespace Raft.Entities
 
         public void UpdateLog(NodeMessage message, Guid entryId)
         {
-            var logEntry = new LogEntry(OperationType.Update, message.Value, entryId);
+            var logEntry = new LogEntry(OperationType.Update, message.Value, entryId, Status.Term);
             Log.Add(logEntry);
         }
 
@@ -69,7 +69,9 @@ namespace Raft.Entities
 
         private void SendVoteRequest(int term)
         {
-            var message = new NodeMessage(term, Name, MessageType.VoteRequest, Name, Guid.NewGuid());
+            var lastLogEntry = LastLogEntry();
+            var value = lastLogEntry == null ? "0,-1" : $"{lastLogEntry.Term},{Log.Count - 1}"; 
+            var message = new NodeMessage(term, value, MessageType.VoteRequest, Name, Guid.NewGuid());
             Broker.Broadcast(message);
         }
 

--- a/Raft/Entities/Node.cs
+++ b/Raft/Entities/Node.cs
@@ -83,7 +83,7 @@ namespace Raft.Entities
 
         public bool HasVotedInTerm(int term)
         {
-            return Status.Term >= term;
+            return Status.LastVote >= term;
         }
 
         public void SendPing()

--- a/Raft/Entities/NodeStatus.cs
+++ b/Raft/Entities/NodeStatus.cs
@@ -22,6 +22,7 @@ namespace Raft.Entities
         public string Name => NodeStatus.Leader;
         
         public int Term { get; set; }
+        public int LastVote { get; set; }
         public override string ToString() => "L";
     }
     
@@ -35,6 +36,7 @@ namespace Raft.Entities
         public string Name => NodeStatus.Follower;
         
         public int Term { get; set; }
+        public int LastVote { get; set; }
         public override string ToString() => "F";
     }
     
@@ -50,6 +52,7 @@ namespace Raft.Entities
         public string Name => NodeStatus.Candidate;
         
         public int Term { get; set; }
+        public int LastVote { get; set; }
         public override string ToString() => "C";
     }
 }

--- a/Raft/NodeStrategy/CandidateStrategy.cs
+++ b/Raft/NodeStrategy/CandidateStrategy.cs
@@ -32,6 +32,11 @@ namespace Raft.NodeStrategy
                 new FollowerStrategy(Node).RespondToMessage(message);
                 return;
             }
+
+            if (message.Term < Node.Status.Term)
+            {
+                return;
+            }
             
             switch (message.Type)
             {

--- a/Raft/NodeStrategy/CandidateStrategy.cs
+++ b/Raft/NodeStrategy/CandidateStrategy.cs
@@ -26,49 +26,15 @@ namespace Raft.NodeStrategy
 
         public void RespondToMessage(NodeMessage message)
         {
+            if (message.Term > Node.Status.Term)
+            {
+                BecomeFollower(message);
+                new FollowerStrategy(Node).RespondToMessage(message);
+                return;
+            }
+            
             switch (message.Type)
             {
-                case MessageType.LogUpdate:
-                    if (message.Term > Node.Status.Term)
-                    {
-                        BecomeFollower(message);
-                        ConfirmLogUpdate(message);
-                    }
-
-                    break;
-
-                case MessageType.LogUpdateConfirmation:
-                    break;
-
-                case MessageType.LogCommit:
-                    if (message.Term > Node.Status.Term)
-                    {
-                        BecomeFollower(message);
-                        CommitLog(message);
-                    }
-
-                    break;
-
-                case MessageType.ValueUpdate:
-                    break;
-
-                case MessageType.Info:
-                    if (message.Term > Node.Status.Term)
-                    {
-                        BecomeFollower(message);
-                    }
-
-                    break;
-
-                case MessageType.VoteRequest:
-                    if (message.Term > Node.Status.Term)
-                    {
-                        BecomeFollower(message);
-                        Node.Vote(message.Term, message.SenderName, message.Id);
-                    }
-
-                    break;
-
                 case MessageType.LeaderVote:
                     if (message.Value != Node.Name)
                     {
@@ -83,7 +49,18 @@ namespace Raft.NodeStrategy
                     }
 
                     break;
-
+                case MessageType.ValueUpdate:
+                    break;
+                case MessageType.LogUpdate:
+                    break;
+                case MessageType.LogUpdateConfirmation:
+                    break;
+                case MessageType.LogCommit:
+                    break;
+                case MessageType.Info:
+                    break;
+                case MessageType.VoteRequest:
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Raft/NodeStrategy/FollowerStrategy.cs
+++ b/Raft/NodeStrategy/FollowerStrategy.cs
@@ -47,6 +47,7 @@ namespace Raft.NodeStrategy
                     if (!Node.HasVotedInTerm(message.Term))
                     {
                         Node.Status.Term = message.Term;
+                        Node.Status.LastVote = message.Term;
                         Vote(message);
                     }
 

--- a/Raft/NodeStrategy/LeaderStrategy.cs
+++ b/Raft/NodeStrategy/LeaderStrategy.cs
@@ -28,6 +28,11 @@ namespace Raft.NodeStrategy
                 new FollowerStrategy(Node).RespondToMessage(message);
                 return;
             }
+
+            if (message.Type != MessageType.ValueUpdate && message.Term < _status.Term)
+            {
+                return;
+            }
             
             switch (message.Type)
             {

--- a/Raft/NodeStrategy/LeaderStrategy.cs
+++ b/Raft/NodeStrategy/LeaderStrategy.cs
@@ -22,6 +22,13 @@ namespace Raft.NodeStrategy
 
         public void RespondToMessage(NodeMessage message)
         {
+            if (message.Term > Node.Status.Term)
+            {
+                BecomeFollower(message);
+                new FollowerStrategy(Node).RespondToMessage(message);
+                return;
+            }
+            
             switch (message.Type)
             {
                 case MessageType.ValueUpdate:
@@ -42,40 +49,18 @@ namespace Raft.NodeStrategy
                     break;
 
                 case MessageType.LogUpdate:
-                    BecomeFollowerIfSentFromNewerTerm(message);
                     break;
                 case MessageType.LogCommit:
-                    BecomeFollowerIfSentFromNewerTerm(message);
                     break;
                 case MessageType.Info:
-                    BecomeFollowerIfSentFromNewerTerm(message);
                     break;
                 case MessageType.VoteRequest:
-                    if (FromHigherTerm(message))
-                    {
-                        BecomeFollower(message);
-                        Node.Vote(message.Term, message.SenderName, message.Id);
-                    }
-
                     break;
                 case MessageType.LeaderVote:
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-        }
-
-        private void BecomeFollowerIfSentFromNewerTerm(NodeMessage message)
-        {
-            if (FromHigherTerm(message))
-            {
-                BecomeFollower(message);
-            }
-        }
-
-        private bool FromHigherTerm(NodeMessage message)
-        {
-            return message.Term >= Node.Status.Term;
         }
 
         private void ResetUpdateConfirmations()


### PR DESCRIPTION
Ensure safe leader election by comparing the candidates last log entry term and index with that of the follower.
According to https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf

> The
RequestVote RPC implements this restriction: the RPC
includes information about the candidate’s log, and the
voter denies its vote if its own log is more up-to-date than
that of the candidate

and 

> Raft determines which of two logs is more up-to-date
by comparing the index and term of the last entries

This prevents backwards nodes from becoming leaders, but also can get the cluster stuck unless log consistency check and log recovery are implemented