### PR TITLE
Fix leader election bug 

### DIFF
--- a/Raft.Test/Communication/FollowerNodeRunnerShould.cs
+++ b/Raft.Test/Communication/FollowerNodeRunnerShould.cs
@@ -13,6 +13,7 @@ namespace Raft.Test.Communication
     {
         private const string TestValue = "test-message";
         private const string NodeName = "test";
+        private const string LeaderName = "leader";
 
         private NodeRunner _nodeRunner;
         private IMessageBroker _messageBroker;
@@ -27,17 +28,18 @@ namespace Raft.Test.Communication
             _timer = Substitute.For<ITimer>();
             _nodeRunner = new NodeRunner(_node, _timer, new StrategySelector(3));
         }
-        
+
         [Test]
         public void UpdateLogAndConfirm_OnLogUpdate()
         {
-            var message = new NodeMessage(0, TestValue, MessageType.LogUpdate, null, Guid.Empty);
+            var message = new NodeMessage(0, TestValue, MessageType.LogUpdate, LeaderName, Guid.Empty);
             _nodeRunner.ReceiveMessage(message);
-            
+
             _node.Log.Count.ShouldBe(1);
             _node.Log[0].Value.ShouldBe(TestValue);
             _node.Log[0].Type.ShouldBe(OperationType.Update);
-            _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.LogUpdateConfirmation));
+            _messageBroker.Received(1).Send(Arg.Is<NodeMessage>(m => m.Type == MessageType.LogUpdateConfirmation),
+                Arg.Is<string>(x => x.Equals(LeaderName)));
         }
 
         [Test]
@@ -45,10 +47,10 @@ namespace Raft.Test.Communication
         {
             var updateId = Guid.NewGuid();
             _node.Log.Add(new LogEntry(OperationType.Update, TestValue, updateId, 0));
-            
+
             var message = new NodeMessage(0, TestValue, MessageType.LogCommit, null, updateId);
             _nodeRunner.ReceiveMessage(message);
-            
+
             _node.Log.Last().Type.ShouldBe(OperationType.Commit);
             _node.Value.ShouldBe(TestValue);
         }
@@ -63,15 +65,15 @@ namespace Raft.Test.Communication
         public void ResetTimer_WhenMessageFromLeaderReceived()
         {
             _nodeRunner.ReceiveMessage(new NodeMessage(1, "test", MessageType.Info, "someSender", Guid.Empty));
-            
+
             _timer.Received(1).Reset();
         }
-        
+
         [Test]
         public void NotResetTimer_WhenMessageIsFromItself()
         {
             _nodeRunner.ReceiveMessage(new NodeMessage(1, "test", MessageType.Info, NodeName, Guid.Empty));
-            
+
             _timer.Received(0).Reset();
         }
     }

--- a/Raft.Test/Entities/NodeShould.cs
+++ b/Raft.Test/Entities/NodeShould.cs
@@ -51,7 +51,7 @@ namespace Raft.Test.Entities
             _node.Log.Add(new LogEntry(OperationType.Update, "value", Guid.NewGuid(), 1));
             _node.BecomeCandidate();
             
-            _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.VoteRequest && m.Value.Equals("1,0")));
+            _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.VoteRequest && m.Value.Equals("1,1")));
         }
 
         [Test]

--- a/Raft.Test/Strategy/CandidateStrategyShould.cs
+++ b/Raft.Test/Strategy/CandidateStrategyShould.cs
@@ -21,9 +21,9 @@ namespace Raft.Test.Strategy
         {
             _messageBroker = Substitute.For<IMessageBroker>();
             _node = new Node(CandidateName, _messageBroker) {Status = new CandidateStatus(CandidateTerm)};
-            _candidateStrategy = new CandidateStrategy(_node, 3 );
+            _candidateStrategy = new CandidateStrategy(_node, 3);
         }
-        
+
         [Test]
         public void AddVotes_OnVoteReceived()
         {
@@ -34,7 +34,7 @@ namespace Raft.Test.Strategy
             candidateStatus.ShouldNotBeNull();
             candidateStatus.ConfirmedNodes.Count.ShouldBe(CandidateTerm);
         }
-        
+
         [Test]
         public void BecomeLeader_OnMajorityOfVotesReceived()
         {
@@ -45,7 +45,7 @@ namespace Raft.Test.Strategy
 
             _node.Status.Name.ShouldBe(NodeStatus.Leader);
         }
-        
+
         [Test]
         public void SendPing_OnBecomingLeader()
         {
@@ -55,7 +55,8 @@ namespace Raft.Test.Strategy
             _candidateStrategy.RespondToMessage(voteB);
 
             _node.Status.Name.ShouldBe(NodeStatus.Leader);
-            _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.Info && m.SenderName == CandidateName));
+            _messageBroker.Received(1)
+                .Broadcast(Arg.Is<NodeMessage>(m => m.Type == MessageType.Info && m.SenderName == CandidateName));
         }
 
         [TestCase(MessageType.LogUpdate)]
@@ -65,10 +66,10 @@ namespace Raft.Test.Strategy
         {
             var fromLeader = new NodeMessage(0, CandidateName, messageType, "L", Guid.Empty);
             _candidateStrategy.RespondToMessage(fromLeader);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Candidate);
         }
-        
+
         [TestCase(MessageType.LogUpdate)]
         [TestCase(MessageType.LogCommit)]
         [TestCase(MessageType.Info)]
@@ -76,7 +77,7 @@ namespace Raft.Test.Strategy
         {
             var fromLeader = new NodeMessage(2, CandidateName, messageType, "L", Guid.Empty);
             _candidateStrategy.RespondToMessage(fromLeader);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Follower);
         }
 
@@ -85,13 +86,13 @@ namespace Raft.Test.Strategy
         {
             var fromLeader = new NodeMessage(2, "new value", MessageType.LogUpdate, "L", Guid.Empty);
             _candidateStrategy.RespondToMessage(fromLeader);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Follower);
             _node.Log.Count.ShouldBe(1);
             _node.LastLogEntry().Value.ShouldBe("new value");
             _node.LastLogEntry().Type.ShouldBe(OperationType.Update);
         }
-        
+
         [Test]
         public void BecomeFollowerAndCommitLog_OnLogCommitFromNewLeader()
         {
@@ -99,46 +100,49 @@ namespace Raft.Test.Strategy
             _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId, 2));
             var fromLeader = new NodeMessage(2, "new value", MessageType.LogCommit, "L", entryId);
             _candidateStrategy.RespondToMessage(fromLeader);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Follower);
             _node.Log.Count.ShouldBe(1);
             _node.LastLogEntry().Value.ShouldBe("new value");
             _node.LastLogEntry().Type.ShouldBe(OperationType.Commit);
         }
-        
+
         [Test]
         public void IgnoreClientRequests()
         {
             var valueUpdate = new NodeMessage(0, CandidateName, MessageType.ValueUpdate, null, Guid.Empty);
             _candidateStrategy.RespondToMessage(valueUpdate);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Candidate);
             _messageBroker.Received(0).Broadcast(Arg.Any<NodeMessage>());
         }
 
         [Test]
-        public void BecomeFollowerAndVot_OnNewerTermStarted()
+        public void BecomeFollowerAndVote_OnNewerTermStarted()
         {
-            var voteRequest = new NodeMessage(CandidateTerm + 1, CandidateName, MessageType.VoteRequest, "C", Guid.Empty);
+            var newCandidateName = "C";
+            var voteRequest =
+                new NodeMessage(CandidateTerm + 1, CandidateName, MessageType.VoteRequest, newCandidateName, Guid.Empty);
             _candidateStrategy.RespondToMessage(voteRequest);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Follower);
-            
+
             _messageBroker.Received(1)
-                .Broadcast(message: Arg.Is<NodeMessage>(m => m.Type == MessageType.LeaderVote && m.SenderName == CandidateName));
+                .Send(Arg.Is<NodeMessage>(m => m.Type == MessageType.LeaderVote && m.SenderName == CandidateName),
+                    Arg.Is<string>(x => x.Equals(newCandidateName)));
         }
 
         [Test]
         public void IgnoreStaleMessages()
         {
-            var voteRequest = new NodeMessage(CandidateTerm - 1, CandidateName, MessageType.VoteRequest, "C", Guid.Empty);
+            var voteRequest =
+                new NodeMessage(CandidateTerm - 1, CandidateName, MessageType.VoteRequest, "C", Guid.Empty);
             _candidateStrategy.RespondToMessage(voteRequest);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Candidate);
-            
+
             _messageBroker.DidNotReceiveWithAnyArgs()
                 .Broadcast(message: Arg.Any<NodeMessage>());
         }
-
     }
 }

--- a/Raft.Test/Strategy/FollowerStrategyShould.cs
+++ b/Raft.Test/Strategy/FollowerStrategyShould.cs
@@ -117,6 +117,17 @@ namespace Raft.Test.Strategy
             
             _messageBroker.Received(expectation ? 1 : 0).Send(Arg.Any<NodeMessage>(), Arg.Is<string>(x => x.Equals(leaderName)));
         }
-        
+
+        [TestCase(MessageType.LogUpdate)]
+        [TestCase(MessageType.LogCommit)]
+        [TestCase(MessageType.Info)]
+        public void UpdateTermToMatchNewerLeader(MessageType messageType)
+        {
+            _node.Status = new FollowerStatus(2);
+            var logUpdate = new NodeMessage(3, "test", messageType, "L", Guid.Empty);
+            _followerStrategy.RespondToMessage(logUpdate);
+
+            _node.Status.Term.ShouldBe(3);
+        }
     }
 }

--- a/Raft.Test/Strategy/FollowerStrategyShould.cs
+++ b/Raft.Test/Strategy/FollowerStrategyShould.cs
@@ -28,11 +28,12 @@ namespace Raft.Test.Strategy
             _followerStrategy = new FollowerStrategy(_node);
         }
 
-        [Test]
-        public void UpdateLogAndConfirm_OnLogUpdate()
+        [TestCase(0)]
+        [TestCase(1)]
+        public void UpdateLogAndConfirm_OnLogUpdate(int termIncrement)
         {
             const string leaderName = "L";
-            var logUpdate = new NodeMessage(FollowerTerm, "test", MessageType.LogUpdate, leaderName, Guid.Empty);
+            var logUpdate = new NodeMessage(FollowerTerm + termIncrement, "test", MessageType.LogUpdate, leaderName, Guid.Empty);
             _followerStrategy.RespondToMessage(logUpdate);
 
             _node.LastLogEntry().Value.ShouldBe("test");
@@ -43,13 +44,14 @@ namespace Raft.Test.Strategy
                      m.SenderName == FollowerName), Arg.Is<string>(x => x.Equals(leaderName)));
         }
 
-        [Test]
-        public void CommitLogAndUpdateValue_OnLogCommit()
+        [TestCase(0)]
+        [TestCase(1)]
+        public void CommitLogAndUpdateValue_OnLogCommit(int termIncrement)
         {
             var entryId = Guid.NewGuid();
             _node.Log.Add(new LogEntry(OperationType.Update, "test", entryId, FollowerTerm));
             
-            var logUpdate = new NodeMessage(FollowerTerm, "test", MessageType.LogCommit, "L", entryId);
+            var logUpdate = new NodeMessage(FollowerTerm + termIncrement, "test", MessageType.LogCommit, "L", entryId);
             _followerStrategy.RespondToMessage(logUpdate);
             
             _node.LastLogEntry().Value.ShouldBe("test");

--- a/Raft.Test/Strategy/FollowerStrategyShould.cs
+++ b/Raft.Test/Strategy/FollowerStrategyShould.cs
@@ -31,15 +31,16 @@ namespace Raft.Test.Strategy
         [Test]
         public void UpdateLogAndConfirm_OnLogUpdate()
         {
-            var logUpdate = new NodeMessage(FollowerTerm, "test", MessageType.LogUpdate, "L", Guid.Empty);
+            const string leaderName = "L";
+            var logUpdate = new NodeMessage(FollowerTerm, "test", MessageType.LogUpdate, leaderName, Guid.Empty);
             _followerStrategy.RespondToMessage(logUpdate);
 
             _node.LastLogEntry().Value.ShouldBe("test");
             _node.LastLogEntry().Type.ShouldBe(OperationType.Update);
             
-            _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(
+            _messageBroker.Received(1).Send(Arg.Is<NodeMessage>(
                 m => m.Type == MessageType.LogUpdateConfirmation &&
-                     m.SenderName == FollowerName));
+                     m.SenderName == FollowerName), Arg.Is<string>(x => x.Equals(leaderName)));
         }
 
         [Test]
@@ -83,11 +84,12 @@ namespace Raft.Test.Strategy
         [Test]
         public void VoteForLeader_WhenNotVotedInTerm()
         {
-            var voteRequest = new NodeMessage(1, "0,-1", MessageType.VoteRequest, "C", Guid.NewGuid());
+            var leaderName = "leader";
+            var voteRequest = new NodeMessage(1, "0,-1", MessageType.VoteRequest, leaderName, Guid.NewGuid());
             _followerStrategy.RespondToMessage(voteRequest);
             
-            _messageBroker.Received(1).Broadcast(Arg.Is<NodeMessage>(
-                m => m.Type == MessageType.LeaderVote && m.SenderName == FollowerName));
+            _messageBroker.Received(1).Send(Arg.Is<NodeMessage>(
+                m => m.Type == MessageType.LeaderVote && m.SenderName == FollowerName), Arg.Is<string>(x => x.Equals(leaderName)));
         }
         
         [Test]
@@ -106,11 +108,12 @@ namespace Raft.Test.Strategy
         {
             _node.Status = new FollowerStatus(1);
             _node.Log.Add(new LogEntry(OperationType.Update, "value", Guid.NewGuid(), 2));
-            
-            var voteRequest = new NodeMessage(FollowerTerm + 1, $"{term},{lastLogIndex}", MessageType.VoteRequest, "C", Guid.NewGuid());
+
+            var leaderName = "leader";
+            var voteRequest = new NodeMessage(FollowerTerm + 1, $"{term},{lastLogIndex}", MessageType.VoteRequest, leaderName, Guid.NewGuid());
             _followerStrategy.RespondToMessage(voteRequest);
             
-            _messageBroker.Received(expectation ? 1 : 0).Broadcast(Arg.Any<NodeMessage>());
+            _messageBroker.Received(expectation ? 1 : 0).Send(Arg.Any<NodeMessage>(), Arg.Is<string>(x => x.Equals(leaderName)));
         }
         
     }

--- a/Raft.Test/Strategy/LeaderStrategyShould.cs
+++ b/Raft.Test/Strategy/LeaderStrategyShould.cs
@@ -22,16 +22,16 @@ namespace Raft.Test.Strategy
             _node = new Node("L", _messageBroker) {Status = new LeaderStatus(1)};
             _leaderStrategy = new LeaderStrategy(_node, 3);
         }
-        
+
         [Test]
         public void AskForLogUpdate_WhenClientRequestsValueUpdate()
         {
             var valueUpdate = new NodeMessage(1, "new value", MessageType.ValueUpdate, null, Guid.Empty);
             _leaderStrategy.RespondToMessage(valueUpdate);
-            
+
             _messageBroker.Received(1).Broadcast(
-                Arg.Is<NodeMessage>(m => m.Type == MessageType.LogUpdate && 
-                m.SenderName == "L"));
+                Arg.Is<NodeMessage>(m => m.Type == MessageType.LogUpdate &&
+                                         m.SenderName == "L"));
         }
 
         [Test]
@@ -40,9 +40,9 @@ namespace Raft.Test.Strategy
             var entryId = Guid.NewGuid();
             _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId, 1));
             var updateConfirmation = new NodeMessage(1, "new value", MessageType.LogUpdateConfirmation, "A", entryId);
-            
+
             _leaderStrategy.RespondToMessage(updateConfirmation);
-            
+
             var leaderStatus = _node.Status as LeaderStatus;
             leaderStatus?.ConfirmedNodes.Count.ShouldBe(1);
         }
@@ -52,7 +52,7 @@ namespace Raft.Test.Strategy
         {
             var entryId = Guid.NewGuid();
             _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId, 1));
-            
+
             var confirmationA = new NodeMessage(1, "new value", MessageType.LogUpdateConfirmation, "A", entryId);
             _leaderStrategy.RespondToMessage(confirmationA);
 
@@ -61,13 +61,13 @@ namespace Raft.Test.Strategy
             _messageBroker.Received(0).Broadcast(
                 Arg.Is<NodeMessage>(m => m.Type == MessageType.LogCommit && m.SenderName == "L"));
         }
-        
+
         [Test]
         public void CommitLogAndUpdateValue_OnMajorityConfirmed()
         {
             var entryId = Guid.NewGuid();
             _node.Log.Add(new LogEntry(OperationType.Update, "new value", entryId, 1));
-            
+
             var confirmationA = new NodeMessage(1, "new value", MessageType.LogUpdateConfirmation, "A", entryId);
             _leaderStrategy.RespondToMessage(confirmationA);
             var confirmationB = new NodeMessage(1, "new value", MessageType.LogUpdateConfirmation, "B", entryId);
@@ -85,10 +85,10 @@ namespace Raft.Test.Strategy
             var leaderStatus = _node.Status as LeaderStatus;
             leaderStatus?.ConfirmedNodes.Add("A");
             leaderStatus?.ConfirmedNodes.Add("L");
-            
+
             var valueUpdate = new NodeMessage(1, "new value", MessageType.ValueUpdate, null, Guid.Empty);
             _leaderStrategy.RespondToMessage(valueUpdate);
-            
+
             leaderStatus?.ConfirmedNodes.Count.ShouldBe(1);
             leaderStatus?.ConfirmedNodes.ShouldContain("L");
         }
@@ -100,22 +100,23 @@ namespace Raft.Test.Strategy
         {
             var fromLeader = new NodeMessage(2, "L1", messageType, "L1", Guid.Empty);
             _leaderStrategy.RespondToMessage(fromLeader);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Follower);
         }
 
         [Test]
         public void BecomeFollowerAndVote_OnNewTermElectionStarted()
         {
-            var fromCandidate = new NodeMessage(2, "L1", MessageType.VoteRequest, "C1", Guid.Empty);
+            const string newCandidateName = "C1";
+            var fromCandidate = new NodeMessage(2, "L1", MessageType.VoteRequest, newCandidateName, Guid.Empty);
             _leaderStrategy.RespondToMessage(fromCandidate);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Follower);
-            _messageBroker.Received(1).Broadcast(
-                Arg.Is<NodeMessage>(m => m.Type == MessageType.LeaderVote && m.SenderName == "L"));
-            
+            _messageBroker.Received(1).Send(
+                Arg.Is<NodeMessage>(m => m.Type == MessageType.LeaderVote && m.SenderName == "L"),
+                Arg.Is<string>(x => x.Equals(newCandidateName)));
         }
-        
+
         [TestCase(MessageType.VoteRequest)]
         [TestCase(MessageType.LogUpdateConfirmation)]
         [TestCase(MessageType.LeaderVote)]
@@ -123,7 +124,7 @@ namespace Raft.Test.Strategy
         {
             var fromCandidate = new NodeMessage(0, "L1", messageType, "C1", Guid.Empty);
             _leaderStrategy.RespondToMessage(fromCandidate);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Leader);
             _messageBroker.DidNotReceiveWithAnyArgs().Broadcast(Arg.Any<NodeMessage>());
         }
@@ -133,10 +134,9 @@ namespace Raft.Test.Strategy
         {
             var fromCandidate = new NodeMessage(0, "L1", MessageType.ValueUpdate, "C1", Guid.Empty);
             _leaderStrategy.RespondToMessage(fromCandidate);
-            
+
             _node.Status.Name.ShouldBe(NodeStatus.Leader);
             _messageBroker.Received(1).Broadcast(Arg.Any<NodeMessage>());
         }
-
     }
 }

--- a/Raft/Communication/IMessageBrokerListener.cs
+++ b/Raft/Communication/IMessageBrokerListener.cs
@@ -11,5 +11,7 @@ namespace Raft.Communication
         
         string Name { get; }
         void Timeout();
+
+        string Display(bool connected);
     }
 }

--- a/Raft/Communication/MessageBroker.cs
+++ b/Raft/Communication/MessageBroker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Raft.Entities;
 
 namespace Raft.Communication
@@ -19,6 +20,17 @@ namespace Raft.Communication
             NotifyListeners(nodeMessage);
         }
 
+        public void Send(NodeMessage nodeMessage, string recipientName)
+        {
+            if (_disconnectedNodes.Contains(nodeMessage.SenderName) ||
+                _disconnectedNodes.Contains(recipientName))
+            {
+                return;
+            }
+            var recipient = _listeners.First(x => x.Name == recipientName);
+            recipient?.ReceiveMessage(nodeMessage);
+        }
+
         public void Broadcast(NodeMessage nodeMessage)
         {
             if (!_disconnectedNodes.Contains(nodeMessage.SenderName))
@@ -26,6 +38,8 @@ namespace Raft.Communication
                 NotifyListeners(nodeMessage);
             }
         }
+        
+        
 
         public void Register(IMessageBrokerListener listener)
         {

--- a/Raft/Communication/MessageBroker.cs
+++ b/Raft/Communication/MessageBroker.cs
@@ -61,6 +61,11 @@ namespace Raft.Communication
                 _disconnectedNodes.Remove(node);
             }
         }
+        
+        public bool IsConnected(IMessageBrokerListener nodeRunner)
+        {
+            return !_disconnectedNodes.Contains(nodeRunner.Name);
+        }
 
         private void NotifyListeners(NodeMessage nodeMessage)
         {

--- a/Raft/Communication/NodeRunner.cs
+++ b/Raft/Communication/NodeRunner.cs
@@ -23,6 +23,13 @@ namespace Raft.Communication
             return $"{Name} ({Node.Status.Term}) {Node.Status} - {Node.DisplayLog}".Replace("  ", " ");
         }
 
+        public string Display(bool connected)
+        {
+            return connected
+                ? $"{Name}  ({Node.Status.Term}) {Node.Status} - {Node.DisplayLog}".Replace("  ", " ")
+                : $"{Name}- ({Node.Status.Term}) {Node.Status} - {Node.DisplayLog}".Replace("  ", " ");
+        }
+
         public NodeRunner(Node node, ITimer timer, StrategySelector strategySelector)
         {
             Node = node;

--- a/Raft/Entities/IMessageBroker.cs
+++ b/Raft/Entities/IMessageBroker.cs
@@ -10,6 +10,8 @@ namespace Raft.Entities
     {
         void Broadcast(NodeMessage message);
         void Broadcast(string newValue);
+
+        void Send(NodeMessage nodeMessage, string recipient);
         
         void Register(IMessageBrokerListener listener);
         

--- a/Raft/Entities/IMessageBroker.cs
+++ b/Raft/Entities/IMessageBroker.cs
@@ -19,5 +19,6 @@ namespace Raft.Entities
         void Connect(IEnumerable<string> nodes);
 
         IEnumerable<IMessageBrokerListener> Listeners { get; }
+        bool IsConnected(IMessageBrokerListener nodeRunner);
     }
 }

--- a/Raft/Entities/Node.cs
+++ b/Raft/Entities/Node.cs
@@ -49,10 +49,10 @@ namespace Raft.Entities
             return Log.Count > 0 ? Log.Last() : null;
         }
 
-        internal void ConfirmLogUpdate(Guid entryId)
+        internal void ConfirmLogUpdate(Guid entryId, string leaderName)
         {
             var nodeMessage = new NodeMessage(Status.Term, null, MessageType.LogUpdateConfirmation, Name, entryId);
-            Broker.Broadcast(nodeMessage);
+            Broker.Send(nodeMessage, leaderName);
         }
 
         internal void SendCommit(NodeMessage message)
@@ -80,7 +80,7 @@ namespace Raft.Entities
             Logger.Debug($"{Name} votes for {candidate}");
             
             var voteMessage = new NodeMessage(term, candidate, MessageType.LeaderVote, Name, electionId);
-            Broker.Broadcast(voteMessage);
+            Broker.Send(voteMessage, candidate);
         }
 
         public bool HasVotedInTerm(int term)

--- a/Raft/Entities/Node.cs
+++ b/Raft/Entities/Node.cs
@@ -70,7 +70,7 @@ namespace Raft.Entities
         private void SendVoteRequest(int term)
         {
             var lastLogEntry = LastLogEntry();
-            var value = lastLogEntry == null ? "0,-1" : $"{lastLogEntry.Term},{Log.Count - 1}"; 
+            var value = lastLogEntry == null ? "0,0" : $"{lastLogEntry.Term},{Log.Count}"; 
             var message = new NodeMessage(term, value, MessageType.VoteRequest, Name, Guid.NewGuid());
             Broker.Broadcast(message);
         }

--- a/Raft/Entities/NodeMessage.cs
+++ b/Raft/Entities/NodeMessage.cs
@@ -12,25 +12,28 @@ namespace Raft.Entities
         public int Term { get; }
 
         public Guid Id { get; }
+
+        public string  Recipient { get; }
         
-        public NodeMessage(int term, string value, MessageType type, string senderName, Guid id)
+        public NodeMessage(int term, string value, MessageType type, string senderName, Guid id, string recipient = null)
         {
             Value = value;
             Type = type;
             SenderName = senderName;
             Id = id;
+            Recipient = recipient;
             Term = term;
         }
     }
 
     public enum MessageType
     {
-        ValueUpdate,
-        LogUpdate,
-        LogUpdateConfirmation,
-        LogCommit,
-        Info,
-        VoteRequest,
-        LeaderVote
+        ValueUpdate, // client appends log entry
+        LogUpdate,  // leader updates the log
+        LogUpdateConfirmation, // follower accepts log update
+        LogCommit, // leader commits a log entry
+        Info, // heartbeat
+        VoteRequest, // candidate initiates election
+        LeaderVote // follower votes for candidate
     }
 }

--- a/Raft/NodeStrategy/BaseStrategy.cs
+++ b/Raft/NodeStrategy/BaseStrategy.cs
@@ -37,9 +37,8 @@ namespace Raft.NodeStrategy
 
         protected bool CandidateIsUpToDate(NodeMessage message)
         {
-            if (Node.LastLogEntry() == null)
+            if (message.Type != MessageType.VoteRequest || Node.LastLogEntry() == null)
             {
-                
                 return true;
             }
             

--- a/Raft/NodeStrategy/BaseStrategy.cs
+++ b/Raft/NodeStrategy/BaseStrategy.cs
@@ -42,8 +42,8 @@ namespace Raft.NodeStrategy
                 return true;
             }
             
-            var (term, index) = ParseLastLogEntryInfo(message);
-            return term >= Node.LastLogEntry().Term && (term != Node.LastLogEntry().Term || index >= Node.Log.Count - 1);
+            var (term, logCount) = ParseLastLogEntryInfo(message);
+            return term >= Node.LastLogEntry().Term && (term != Node.LastLogEntry().Term || logCount >= Node.Log.Count);
         }
 
         private static (int term, int index) ParseLastLogEntryInfo(NodeMessage message)

--- a/Raft/NodeStrategy/BaseStrategy.cs
+++ b/Raft/NodeStrategy/BaseStrategy.cs
@@ -27,7 +27,7 @@ namespace Raft.NodeStrategy
         protected void ConfirmLogUpdate(NodeMessage message)
         {
             Node.UpdateLog(message, message.Id);
-            Node.ConfirmLogUpdate(message.Id);
+            Node.ConfirmLogUpdate(message.Id, message.SenderName);
         }
 
         protected void CommitLog(NodeMessage message)

--- a/Raft/NodeStrategy/BaseStrategy.cs
+++ b/Raft/NodeStrategy/BaseStrategy.cs
@@ -8,7 +8,7 @@ namespace Raft.NodeStrategy
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         protected Node Node;
-
+        
         protected void BecomeLeader()
         {
             Logger.Debug($"{Node.Name} becomes leader, term: {Node.Status.Term}");
@@ -50,6 +50,11 @@ namespace Raft.NodeStrategy
         {
             var lastLogEntryInfo = message.Value.Split(",");
             return (int.Parse(lastLogEntryInfo[0]), int.Parse(lastLogEntryInfo[1]));
+        }
+
+        protected virtual bool IsFromOlderTerm(NodeMessage message)
+        {
+            return message.Term < Node.Status.Term;
         }
     }
 }

--- a/Raft/NodeStrategy/BaseStrategy.cs
+++ b/Raft/NodeStrategy/BaseStrategy.cs
@@ -34,5 +34,23 @@ namespace Raft.NodeStrategy
         {
             Node.CommitLog(message);
         }
+
+        protected bool CandidateIsUpToDate(NodeMessage message)
+        {
+            if (Node.LastLogEntry() == null)
+            {
+                
+                return true;
+            }
+            
+            var (term, index) = ParseLastLogEntryInfo(message);
+            return term >= Node.LastLogEntry().Term && (term != Node.LastLogEntry().Term || index >= Node.Log.Count - 1);
+        }
+
+        private static (int term, int index) ParseLastLogEntryInfo(NodeMessage message)
+        {
+            var lastLogEntryInfo = message.Value.Split(",");
+            return (int.Parse(lastLogEntryInfo[0]), int.Parse(lastLogEntryInfo[1]));
+        }
     }
 }

--- a/Raft/NodeStrategy/CandidateStrategy.cs
+++ b/Raft/NodeStrategy/CandidateStrategy.cs
@@ -26,15 +26,15 @@ namespace Raft.NodeStrategy
 
         public void RespondToMessage(NodeMessage message)
         {
+            if (IsFromOlderTerm(message))
+            {
+                return;
+            }
+            
             if (message.Term > Node.Status.Term)
             {
                 BecomeFollower(message);
                 new FollowerStrategy(Node).RespondToMessage(message);
-                return;
-            }
-
-            if (message.Term < Node.Status.Term)
-            {
                 return;
             }
             

--- a/Raft/NodeStrategy/FollowerStrategy.cs
+++ b/Raft/NodeStrategy/FollowerStrategy.cs
@@ -22,7 +22,7 @@ namespace Raft.NodeStrategy
             switch (message.Type)
             {
                 case MessageType.LogUpdate:
-                    if (message.Term == Node.Status.Term)
+                    if (message.Term >= Node.Status.Term)
                     {
                         ConfirmLogUpdate(message);
                     }
@@ -33,7 +33,7 @@ namespace Raft.NodeStrategy
                     break;
 
                 case MessageType.LogCommit:
-                    if (message.Term == Node.Status.Term)
+                    if (message.Term >= Node.Status.Term)
                     {
                         CommitLog(message);
                     }

--- a/Raft/NodeStrategy/FollowerStrategy.cs
+++ b/Raft/NodeStrategy/FollowerStrategy.cs
@@ -27,6 +27,7 @@ namespace Raft.NodeStrategy
             switch (message.Type)
             {
                 case MessageType.LogUpdate:
+                    Node.Status.Term = message.Term;
                     ConfirmLogUpdate(message);
                     break;
 
@@ -34,6 +35,7 @@ namespace Raft.NodeStrategy
                     break;
 
                 case MessageType.LogCommit:
+                    Node.Status.Term = message.Term;
                     CommitLog(message);
                     break;
 
@@ -41,6 +43,7 @@ namespace Raft.NodeStrategy
                     break;
 
                 case MessageType.Info:
+                    Node.Status.Term = message.Term;
                     break;
 
                 case MessageType.VoteRequest:

--- a/Raft/NodeStrategy/LeaderStrategy.cs
+++ b/Raft/NodeStrategy/LeaderStrategy.cs
@@ -22,7 +22,7 @@ namespace Raft.NodeStrategy
 
         public void RespondToMessage(NodeMessage message)
         {
-            if (message.Term > Node.Status.Term)
+            if (message.Term > Node.Status.Term && CandidateIsUpToDate(message))
             {
                 BecomeFollower(message);
                 new FollowerStrategy(Node).RespondToMessage(message);

--- a/Raft/NodeStrategy/LeaderStrategy.cs
+++ b/Raft/NodeStrategy/LeaderStrategy.cs
@@ -22,15 +22,15 @@ namespace Raft.NodeStrategy
 
         public void RespondToMessage(NodeMessage message)
         {
+            if (IsFromOlderTerm(message))
+            {
+                return;
+            }
+            
             if (message.Term > Node.Status.Term && CandidateIsUpToDate(message))
             {
                 BecomeFollower(message);
                 new FollowerStrategy(Node).RespondToMessage(message);
-                return;
-            }
-
-            if (message.Type != MessageType.ValueUpdate && message.Term < _status.Term)
-            {
                 return;
             }
             
@@ -66,6 +66,11 @@ namespace Raft.NodeStrategy
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+
+        protected override bool IsFromOlderTerm(NodeMessage message)
+        {
+            return message.Type != MessageType.ValueUpdate && base.IsFromOlderTerm(message);
         }
 
         private void ResetUpdateConfirmations()

--- a/Raft/Program.cs
+++ b/Raft/Program.cs
@@ -8,6 +8,7 @@ namespace Raft
         private static void Main(string[] args)
         {
             Console.WriteLine("Hello Raft!");
+            Console.WriteLine("Write ? to see what you can do");
             
             new RaftRunner().Run();
 

--- a/Raft/Runner/RaftRunner.cs
+++ b/Raft/Runner/RaftRunner.cs
@@ -122,6 +122,7 @@ namespace Raft.Runner
             Console.WriteLine("value - to enter new value ");
             Console.WriteLine("disconnect - to disconnect one or more nodes");
             Console.WriteLine("connect - to reconnect one or more nodes");
+            Console.WriteLine("timeout - to trigger and make one or more nodes candidates");
         }
 
         private void ConfigureLogging()

--- a/Raft/Runner/RaftRunner.cs
+++ b/Raft/Runner/RaftRunner.cs
@@ -34,12 +34,12 @@ namespace Raft.Runner
             {
                 var command = Console.ReadLine();
 
-                if (string.IsNullOrEmpty(command))
+                if (command == "quit")
                 {
                     return;
                 }
 
-                if (command.Equals("?"))
+                if (string.IsNullOrEmpty(command) || command.Equals("?"))
                 {
                     ShowHelp();
                 }

--- a/Raft/Runner/RaftRunner.cs
+++ b/Raft/Runner/RaftRunner.cs
@@ -85,7 +85,7 @@ namespace Raft.Runner
         {
             foreach (var nodeRunner in _nodeRunners)
             {
-                Console.WriteLine(nodeRunner);
+                Console.WriteLine(nodeRunner.Display(Broker.IsConnected(nodeRunner)));
             }
         }
 
@@ -93,12 +93,14 @@ namespace Raft.Runner
         {
             var nodes = GetNodesForCommand(command);
             Broker.Connect(nodes.ToList());
+            DisplayStatus();
         }
 
         private void DisconnectNodes(string command)
         {
             var nodes = GetNodesForCommand(command);
             Broker.Disconnect(nodes.ToList());
+            DisplayStatus();
         }
 
         private static IEnumerable<string> GetNodesForCommand(string command)


### PR DESCRIPTION
Fixed a bug that got the cluster stuck when a candidate was out of date:
- disconnect a node
- set value - the node is now behind
- connect the node
- timeout the node
The node starts an election but is behind so can never become a leader. It will restart the election endlessly as it will never get a message with newer term

The solution: the leader increases its term if it gets a vote request from an of date candidate.
This requires followers to make sure their terms are up to date at each leader message

Also improved the runner adding new commands and improving the status display